### PR TITLE
(#244) Fix .info['annualReportExpenseRatio'] for ETFs

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -346,6 +346,13 @@ class TickerBase():
         except Exception:
             pass
 
+        expenseRatio = (data
+                       .get('fundProfile', {})
+                       .get('feesExpensesInvestment', {})
+                       .get('annualReportExpenseRatio', None))
+        if expenseRatio is not None:
+            self._info['annualReportExpenseRatio'] = expenseRatio
+
         # events
         try:
             cal = _pd.DataFrame(


### PR DESCRIPTION
As reported in issue #244, there is a bug with querying for an ETF's
expense ratio. For mutual funds, this value is found in
`.info['annualReportExpenseRatio']`, but for ETFs it is not.

```py
>>> import yfinance as yf
>>> print(yf.Ticker('VTSAX').info['annualReportExpenseRatio'])
0.0004
>>> print(yf.Ticker('VTI').info['annualReportExpenseRatio'])
None
```

The github user @ycc1107 commented on the issue, identifying the root
cause, which is that for some reason this value is only available inside
the `'fundProfile'` key of the `data` dictionary, a key that is only
present when querying mutual funds and ETFs.
The `'fundProfile'` key leads to a dictionary with a
`'feesExpensesInvestment'` key, which leads to a dictionary with an
`'annualReportExpenseRatio'` key, which has the value we need.

The github user @ycc1107 opened a PR to fix this issue, but I'm
concerned that it changes too much, as it recursively merges the
entirety of the `'fundProfile'` dictionary into the `.info` dictionary.
So I'm proposing an alternative fix here that attempts to write only
`.info['annualReportExpenseRatio']` and nothing else.